### PR TITLE
Job id for a new job should be size-1

### DIFF
--- a/cs3100/projects/scheduler/Simulation.cpp
+++ b/cs3100/projects/scheduler/Simulation.cpp
@@ -19,7 +19,7 @@ namespace cs3100
   {
     Job j(curTime,parameters.devices,parameters.cacheSize);
     jobs.push_back(j);
-    ready->add(jobs.size());
+    ready->add(jobs.size()-1);
     scheduleJob();
   }
 


### PR DESCRIPTION
The job id for a new job should be size-1 instead of size as throughout the simulator it uses the job id to get the job.  If using size the simulator will throw out of bounds exceptions.