### PR TITLE
Initializing idleCpus

### DIFF
--- a/cs3100/projects/scheduler/Simulation.cpp
+++ b/cs3100/projects/scheduler/Simulation.cpp
@@ -100,6 +100,7 @@ namespace cs3100
 
   void Simulation::run()
   {
+    idleCpu = parameters.cpus;
     auto startTime = 0.0f;
     for (int i = 0; i < parameters.jobs; ++i)
     {


### PR DESCRIPTION
Since idleCpus was never initialized it never actually completes any cpu jobs.  I initialized idleCpus to the parameter value at the beginning of run.