### PR TITLE
Added long description for tsc_patio

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ Course materials for various computer science courses I have taught at Utah Stat
 |1410|Introduction to CS II|
 |3100|Operating Systems and Concurrency|
 |3450|Software Engineering|
+|4700|Programming Languages|
 |5400|Computer Graphics I|

--- a/cs4700/projects/prolog/adventure/adventure.pl
+++ b/cs4700/projects/prolog/adventure/adventure.pl
@@ -255,7 +255,7 @@ long_desc(ser_1st_floor,"").
 long_desc(ser_2nd_floor,"").
 long_desc(small_disk,"A small disk pulsates in your hand, glowing an toxic green color as it breathes slowly, a slight warm gasey feel pukes from the disk.").
 long_desc(special_collections,"").
-long_desc(tsc_patio,"").
+long_desc(tsc_patio,"An open area with birds chirping and hipsters drinking their coffee. You won't find any CS majors here as they're all in cavedwelling in Old Main.").
 long_desc(tunnels_east,"").
 long_desc(tunnels_north,"").
 long_desc(tunnels_west,"").


### PR DESCRIPTION
Added long description for tsc_patio. 
"An open area with birds chirping and hipsters drinking their coffee. You won't find any CS majors here as they're all in cavedwelling in Old Main."