### PR TITLE
Update adventure.pl

### DIFF
--- a/cs4700/projects/prolog/adventure/adventure.pl
+++ b/cs4700/projects/prolog/adventure/adventure.pl
@@ -109,7 +109,6 @@ location(laundry_soap,laundry_room).
 location(lost_homework,engr).
 location(medium_disk,pylon_a).
 location(movie, roomate_room).
-location(note,bedroom).
 location(pylon_a,secret_lab).
 location(pylon_b,secret_lab).
 location(pylon_c,secret_lab).


### PR DESCRIPTION
The rule, "location(note, bedroom)." had a duplicate.