### PR TITLE
Longer long_expression.cpsl

### DIFF
--- a/shared/cpsl/examples/simple_expressions/long_expression.cpsl
+++ b/shared/cpsl/examples/simple_expressions/long_expression.cpsl
@@ -1,5 +1,5 @@
 var
- a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p : integer;
+ a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r : integer;
  x,y,z:integer;
 
 begin
@@ -19,9 +19,11 @@ begin
  n:=14;
  o:=15;
  p:=16;
+ q:=17;
+ r:=18;
 
 x:=(((a+b)*(c+d))-((e+f)*(g+h)))/(((i+j)*(k+l))-((m+n)*(o+p)));
-y:=(a+(b+(c+(d+(e+(f+(g+(h+(i+(j+(k+(l+(m+(n+(o+(p))))))))))))))));
+y:=(a+(b+(c+(d+(e+(f+(g+(h+(i+(j+(k+(l+(m+(n+(o+(p+(q+(r))))))))))))))))));
 z:=(a)/(b)
   +(a*a)/(b*b)
   +(a*a*a)/(b*b*b)

--- a/shared/cpsl/examples/simple_expressions/long_expression.cpsl
+++ b/shared/cpsl/examples/simple_expressions/long_expression.cpsl
@@ -1,5 +1,5 @@
 var
- a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r : integer;
+ a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s : integer;
  x,y,z:integer;
 
 begin
@@ -21,9 +21,10 @@ begin
  p:=16;
  q:=17;
  r:=18;
+ s:=19;
 
 x:=(((a+b)*(c+d))-((e+f)*(g+h)))/(((i+j)*(k+l))-((m+n)*(o+p)));
-y:=(a+(b+(c+(d+(e+(f+(g+(h+(i+(j+(k+(l+(m+(n+(o+(p+(q+(r))))))))))))))))));
+y:=(a+(b+(c+(d+(e+(f+(g+(h+(i+(j+(k+(l+(m+(n+(o+(p+(q+(r+(s)))))))))))))))))));
 z:=(a)/(b)
   +(a*a)/(b*b)
   +(a*a*a)/(b*b*b)


### PR DESCRIPTION
The current long_expression does not require lazy register allocation. The expression `y := (a+(...` is just short enough that it only uses 16 registers, one for each variable a-p. This additional length requires that registers be allocated no sooner than they are needed. I was able to compile both the original and longer long expression using lazy register allocation with at most 5 registers allocated at one time.