### PR TITLE
Correct the spelling of character type

### DIFF
--- a/shared/cpsl/examples/function/hanoi.cpsl
+++ b/shared/cpsl/examples/function/hanoi.cpsl
@@ -1,6 +1,6 @@
 var disks : integer;
 
-procedure moveTower(var disk: integer; source,dest,spare: character);
+procedure moveTower(var disk: integer; source,dest,spare: char);
 begin
 	if(disk=1) then
 		write("Move ",disk," from ",source," to ",dest,'\n');


### PR DESCRIPTION
Per the CPSL standard, Table 4.1: Predefined Identifiers in CPSL, the basic character type is spelled `char` or `CHAR` not character