### PR TITLE
Correction to display_pylons

### DIFF
--- a/cs4700/projects/prolog/adventure/adventure.pl
+++ b/cs4700/projects/prolog/adventure/adventure.pl
@@ -401,6 +401,7 @@ display_top_disk(Pylon):-location(small_disk, Pylon),location(medium_disk,Pylon)
 display_top_disk(_):- write("   |   "),!.
 
 display_middle_disk(Pylon):- location(small_disk,Pylon), location(medium_disk,Pylon), not(location(large_disk,Pylon)),write("  [|]  "),!.
+display_middle_disk(Pylon):- location(large_disk,Pylon), location(small_disk,Pylon), not(location(medium_disk,Pylon)), write("  [|]  "),!.
 display_middle_disk(Pylon):- location(large_disk,Pylon), location(medium_disk,Pylon), write(" [-|-] "),!.
 display_middle_disk(_):- write("   |   "),!.
 


### PR DESCRIPTION
It is legal to place the small disk on top of the large disk. However as it was before it would not display the small disk if it was above the large disk. This line will now display the small disk above the large one if the medium disk is not present.